### PR TITLE
Increase default status update interval to 30 seconds

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -49,7 +49,7 @@ const configFile = "config.json"
 
 // defaultConfig contains all default configuration values
 var defaultConfig = ClientConfig{
-	StatusUpdateInterval:     5 * time.Second,
+	StatusUpdateInterval:     30 * time.Second,
 	DisableCommands:          false,
 	VerificationCodeLength:   6,
 	VerificationCodeAttempts: 3,

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -207,7 +207,7 @@ func TestAutoCorrection(t *testing.T) {
 		t.Errorf("Expected validation to succeed with auto-correction, got: %v", err)
 	}
 
-	if correctedCfg.StatusUpdateInterval != 5*time.Second {
+	if correctedCfg.StatusUpdateInterval != 30*time.Second {
 		t.Errorf("Expected auto-corrected StatusUpdateInterval to be 5s, got %v", correctedCfg.StatusUpdateInterval)
 	}
 
@@ -250,7 +250,7 @@ func TestStatusUpdateInterval(t *testing.T) {
 
 	// Test default value
 	interval := cfg.GetStatusUpdateInterval()
-	if interval != 5*time.Second {
+	if interval != 30*time.Second {
 		t.Errorf("Expected default status update interval of 5s, got %v", interval)
 	}
 
@@ -264,14 +264,14 @@ func TestStatusUpdateInterval(t *testing.T) {
 	// Test zero value falls back to default
 	cfg.StatusUpdateInterval = 0
 	interval = cfg.GetStatusUpdateInterval()
-	if interval != 5*time.Second {
+	if interval != 30*time.Second {
 		t.Errorf("Expected fallback to default status update interval of 5s, got %v", interval)
 	}
 
 	// Test negative value falls back to default
 	cfg.StatusUpdateInterval = -1 * time.Second
 	interval = cfg.GetStatusUpdateInterval()
-	if interval != 5*time.Second {
+	if interval != 30*time.Second {
 		t.Errorf("Expected fallback to default status update interval of 5s, got %v", interval)
 	}
 }


### PR DESCRIPTION
Change the default status update interval from 5 seconds to 30 seconds to improve performance and reduce frequency of updates.